### PR TITLE
Append instead of overriding trap handler (fixes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ TODO RUNS false
 # you can mark known test cases as SKIP when then
 # are known not to run under some condition
 SKIP test $(uname -s) == Darwin # Tests dont run under Darwin
+```
 
 #### Running Skip Tests
 

--- a/osht.sh
+++ b/osht.sh
@@ -23,6 +23,7 @@
 : ${OSHT_STDIO=$($OSHT_MKTEMP)}
 : ${OSHT_VERBOSE=}
 : ${OSHT_WATCH=}
+: ${OSHT_OVERRIDE_TRAP=}
 
 : ${_OSHT_CURRENT_TEST_FILE=$($OSHT_MKTEMP)}
 : ${_OSHT_CURRENT_TEST=0}
@@ -100,7 +101,19 @@ function _osht_cleanup {
     exit $rv
 }
 
-trap _osht_cleanup INT TERM EXIT
+appendTrap() {
+    HANDLER=$1
+    shift
+    SIGNALS="$*"
+    eval "set -- $(trap -p ${SIGNALS})"
+    trap -- "${3}${3:+;}${HANDLER}" ${SIGNALS}
+}
+
+if [ -n "$OSHT_OVERRIDE_TRAP" ]; then
+	trap _osht_cleanup INT TERM EXIT
+else
+	appendTrap _osht_cleanup INT TERM EXIT
+fi
 
 function _osht_xmlencode {
     sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' 


### PR DESCRIPTION
Also fixes a missing triple quote on README.

Introduces `OSHT_TRAP_OVERRIDE` to revert to previous behavior, as a way to avoid pre-existing trap handlers that exit. I'd normally prepend instead of append to avoid that issue, but OSHT trap handler calls `exit`, which prevents other handlers from running.