### PR TITLE
Fix JUnit XML output (fixes #5)

### DIFF
--- a/osht.sh
+++ b/osht.sh
@@ -121,7 +121,8 @@ function _osht_timestamp {
 function _osht_init_junit {
     cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites failures="$(_osht_failed)" name="$0" tests="$_OSHT_PLANNED_TESTS" time="$SECONDS" timestamp="$(_osht_timestamp)" >
+<testsuites>
+<testsuite failures="$(_osht_failed)" name="$0" tests="$_OSHT_PLANNED_TESTS" time="$SECONDS" timestamp="$(_osht_timestamp)" >
 EOF
 }
 
@@ -147,6 +148,7 @@ EOF
 
 function _osht_end_junit {
     cat <<EOF
+</testsuite>
 </testsuites>
 EOF
 }


### PR DESCRIPTION
Researching into this, I was able to confirm the current format is incorrect. In fact, I couldn't even see the results in the browser I used, until I applied the fix. Looking at [one of the documented schemas](https://llg.cubic.org/docs/junit/) I found, I could see the attributes being used corresponded to the `testcase` tag instead of the `testcases` tag, so I fixed it by introducing a new `testcases` tag and renaming the existing one.